### PR TITLE
Address JavaScript Number conversion limitations in UniversalNumber.js

### DIFF
--- a/docs/conversion-enhancements.md
+++ b/docs/conversion-enhancements.md
@@ -2,6 +2,55 @@
 
 The Conversion module is a vital component of the Math-JS library, providing utilities for converting between different number representations. This module implements the Prime Framework's requirements for direct base conversions via universal coordinates, coordinate transformations, and efficient serialization formats. The enhancements described in this document have been implemented to significantly improve performance, flexibility, and interoperability while maintaining strict adherence to the Prime Framework's specifications.
 
+## JavaScript Number Conversion Limitations
+
+When converting UniversalNumber to JavaScript Number via `toNumber()`, the library now provides several options to handle numbers that exceed JavaScript's safe integer limits:
+
+```javascript
+const { UniversalNumber } = require('math-js')
+
+// Create a very large number
+const largeNumber = new UniversalNumber('1234567890123456789012345')
+
+// Attempt to convert to Number with different options
+try {
+  // Default behavior - throws error for values outside safe integer range
+  const num1 = largeNumber.toNumber()  // Throws PrimeMathError
+} catch (e) {
+  console.error('Default conversion:', e.message) 
+}
+
+// Use approximate conversion (will lose precision)
+const approxNum = largeNumber.toNumber({ allowApproximate: true })
+console.log('Approximate:', approxNum)  // Returns approximate value with loss of precision
+
+// Use suppressErrors option (returns Infinity)
+const infinityNum = largeNumber.toNumber({ suppressErrors: true })
+console.log('With suppressErrors:', infinityNum)  // Returns Infinity
+
+// Use scientific notation approximation with specified precision
+const scientificNum = largeNumber.toApproximateNumber({ significantDigits: 6 })
+console.log('Scientific notation:', scientificNum)
+console.log('Scientific string:', scientificNum.toExponential(5))  // 1.23457e+24
+
+// Format as string with different notations
+console.log('Scientific format:', largeNumber.formatNumber({ notation: 'scientific', precision: 6 }))  // "1.23457e24"
+console.log('Engineering format:', largeNumber.formatNumber({ notation: 'engineering', precision: 6 }))  // "1.23457e24"
+console.log('Compact format:', largeNumber.formatNumber({ notation: 'compact' }))  // "1.23Q"
+console.log('Grouped format:', largeNumber.formatNumber({ groupDigits: true }))  // "1,234,567,890,123,456,789,012,345"
+
+// Get number parts for custom display
+const parts = largeNumber.getNumberParts()
+console.log('Number parts:', parts)
+// {
+//   sign: 1,
+//   integerPart: '1',
+//   fractionalPart: '234567890123456789012345',
+//   exponent: 24,
+//   isExponentInRange: true
+// }
+```
+
 ## Key Enhancements
 
 ### 1. Direct Base Conversion via Universal Coordinates

--- a/examples/large-number-conversion-example.js
+++ b/examples/large-number-conversion-example.js
@@ -1,0 +1,77 @@
+/**
+ * Example demonstrating large number conversion options in UniversalNumber
+ */
+
+const { UniversalNumber } = require('../src')
+
+console.log('UniversalNumber Large Number Conversion Example')
+console.log('==============================================')
+
+// Create a very large number
+const largeNumber = new UniversalNumber('123456789012345678901234567890')
+console.log(`\nLarge number: ${largeNumber.toString()}`)
+console.log(`Digits: ${largeNumber.toString().length}`)
+
+// Attempt to convert to Number with different options
+console.log('\n1. Default toNumber() behavior:')
+try {
+  // Default behavior - throws error for values outside safe integer range
+  const num1 = largeNumber.toNumber()
+  console.log(`   Result: ${num1}`) // This won't run
+} catch (e) {
+  console.log(`   Error: ${e.message}`)
+}
+
+// Use approximate conversion (will lose precision)
+console.log('\n2. toNumber() with allowApproximate option:')
+const approxNum = largeNumber.toNumber({ allowApproximate: true })
+console.log(`   Result: ${approxNum}`)
+console.log(`   Original: ${largeNumber.toString()}`)
+console.log(`   Note: Precision has been lost`)
+
+// Use suppressErrors option (returns Infinity)
+console.log('\n3. toNumber() with suppressErrors option:')
+const infinityNum = largeNumber.toNumber({ suppressErrors: true })
+console.log(`   Result: ${infinityNum}`)
+
+// Use scientific notation approximation
+console.log('\n4. toApproximateNumber() for scientific notation:')
+const scientificNum = largeNumber.toApproximateNumber()
+console.log(`   Result: ${scientificNum}`)
+console.log(`   As scientific: ${scientificNum.toExponential(14)}`)
+
+// Control precision
+console.log('\n5. toApproximateNumber() with controlled precision:')
+const preciseNum = largeNumber.toApproximateNumber({ significantDigits: 5 })
+console.log(`   Result with 5 significant digits: ${preciseNum.toExponential(4)}`)
+
+// Format as string with different notations
+console.log('\n6. formatNumber() with different notations:')
+console.log(`   Scientific notation: ${largeNumber.formatNumber({ notation: 'scientific', precision: 6 })}`)
+console.log(`   Engineering notation: ${largeNumber.formatNumber({ notation: 'engineering', precision: 6 })}`)
+console.log(`   Compact notation: ${largeNumber.formatNumber({ notation: 'compact' })}`)
+console.log(`   Standard with grouping: ${largeNumber.formatNumber({ groupDigits: true })}`)
+
+// Format in different bases with grouping
+console.log('\n7. formatNumber() with different bases:')
+console.log(`   Binary (grouped): ${largeNumber.formatNumber({ base: 2, groupDigits: true, groupSeparator: '_' })}`)
+console.log(`   Hex (grouped): ${largeNumber.formatNumber({ base: 16, groupDigits: true, groupSeparator: ' ' })}`)
+
+// Get number parts for custom display
+console.log('\n8. getNumberParts() for custom display:')
+const parts = largeNumber.getNumberParts()
+console.log('   Number parts:')
+console.log(`   - Sign: ${parts.sign}`)
+console.log(`   - Integer part: ${parts.integerPart}`)
+console.log(`   - Fractional part: ${parts.fractionalPart}`)
+console.log(`   - Exponent: ${parts.exponent}`)
+console.log(`   - Is exponent in range: ${parts.isExponentInRange}`)
+
+// Example for a negative number
+console.log('\n9. Handling negative numbers:')
+const negativeNumber = new UniversalNumber('-98765432109876543210')
+console.log(`   Negative number: ${negativeNumber.toString()}`)
+console.log(`   Scientific notation: ${negativeNumber.formatNumber({ notation: 'scientific', precision: 5 })}`)
+console.log(`   Approximate value: ${negativeNumber.toApproximateNumber().toExponential(4)}`)
+
+console.log('\nEnd of example')


### PR DESCRIPTION
## Summary
- Enhanced toNumber() with allowApproximate and suppressErrors options
- Added toApproximateNumber() for scientific notation approximation
- Added formatNumber() with scientific, engineering, compact notations
- Added getNumberParts() for custom display formatting
- Updated documentation and tests
- Added comprehensive example

## Test plan
- Run \
> uor-math-js@0.1.0 test
> jest universalNumber.test.js\

  Invalid testPattern universalNumber.test.js\ supplied. Running all tests instead.
  Invalid testPattern universalNumber.test.js\ supplied. Running all tests instead. to verify tests pass
- Run the example file: \
- Verify linting and typechecking pass

Closes #39