### PR TITLE
Remove primality verification threshold in UniversalNumber.js

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,7 +149,28 @@ math.configure({
   primalityTesting: {
     millerRabinRounds: 40,           // Number of Miller-Rabin rounds
     deterministicTestLimit: 20,       // Max digits for deterministic primality testing
-    useTrialDivision: true           // Whether to use trial division before advanced tests
+    useTrialDivision: true,          // Whether to use trial division before advanced tests
+    verificationThreshold: 1000000    // Threshold for using Miller-Rabin vs simple primality test
+  }
+});
+```
+
+#### Primality Verification Threshold
+
+The `verificationThreshold` setting controls when to switch between simple primality testing and more advanced methods like Miller-Rabin:
+
+- For numbers **below** the threshold, a faster but still accurate primality test is used
+- For numbers **above** the threshold, the more rigorous Miller-Rabin test with configurable rounds is used
+
+Adjust this threshold based on your performance needs:
+
+```javascript
+math.configure({
+  primalityTesting: {
+    // Use faster primality testing for larger numbers (if you're confident in their primality)
+    verificationThreshold: 10000000,
+    // Increase Miller-Rabin rounds for more confidence when using the advanced test
+    millerRabinRounds: 60
   }
 });
 ```

--- a/examples/configuration-example.js
+++ b/examples/configuration-example.js
@@ -97,7 +97,8 @@ const customProfile = {
     }
   },
   primalityTesting: {
-    millerRabinRounds: 30
+    millerRabinRounds: 30,
+    verificationThreshold: 2000000  // Use Miller-Rabin for numbers > 2 million
   }
 };
 
@@ -114,5 +115,12 @@ console.log('Optimized trial division threshold:', factConfig.thresholds.optimiz
 console.log('Pollard\'s Rho threshold:', factConfig.thresholds.pollardRho, 'digits');
 console.log('Elliptic Curve Method threshold:', factConfig.thresholds.ecm, 'digits');
 console.log('Quadratic Sieve threshold:', factConfig.thresholds.quadraticSieve, 'digits');
+
+// Show primality testing configuration
+console.log('\n9. Primality testing configuration:');
+const primalityConfig = math.getConfig().primalityTesting;
+console.log('Miller-Rabin rounds:', primalityConfig.millerRabinRounds);
+console.log('Verification threshold:', primalityConfig.verificationThreshold);
+console.log('Deterministic test limit:', primalityConfig.deterministicTestLimit, 'digits');
 
 console.log('\nConfiguration example completed.');

--- a/src/UniversalNumber.js
+++ b/src/UniversalNumber.js
@@ -176,13 +176,17 @@ class UniversalNumber {
         throw new PrimeMathError(`Prime factor ${prime} must be greater than 1`)
       }
       
-      // Verify primality for smaller numbers
-      if (prime < 1000000n && !isPrime(prime)) {
+      // Verify primality using appropriate method based on size
+      // Get the configurable primality verification threshold
+      const verificationThreshold = BigInt(config.primalityTesting.verificationThreshold)
+      
+      // For smaller numbers, use the fast isPrime check
+      if (prime < verificationThreshold && !isPrime(prime)) {
         throw new PrimeMathError(`Factor ${prime} is not a prime number`)
       }
       
-      // Use Miller-Rabin test for larger numbers
-      if (prime >= 1000000n && !millerRabinTest(prime)) {
+      // For larger numbers, use Miller-Rabin test with configurable rounds
+      if (prime >= verificationThreshold && !millerRabinTest(prime, { rounds: config.primalityTesting.millerRabinRounds })) {
         throw new PrimeMathError(`Factor ${prime} is not a prime number`)
       }
 

--- a/src/config.js
+++ b/src/config.js
@@ -262,7 +262,15 @@ const defaultConfig = {
      * Acts as a safety limit to prevent memory exhaustion
      * @type {number}
      */
-    maxPrimesGenerated: 10000000
+    maxPrimesGenerated: 10000000,
+    
+    /**
+     * Threshold for using different primality testing algorithms
+     * Numbers below this threshold use simple primality test
+     * Numbers above this threshold use Miller-Rabin test
+     * @type {number}
+     */
+    verificationThreshold: 1000000
   },
   
   /**


### PR DESCRIPTION
## Summary
- Add configurable primality verification threshold to config.js
- Update UniversalNumber validation logic to use the configurable threshold
- Configure Miller-Rabin test with configurable rounds for better security
- Update documentation and examples to demonstrate the new configuration options

## Test plan
- Verified that primality validation works with different threshold values
- Tested with different Miller-Rabin rounds for improved detection accuracy
- All UniversalNumber tests pass with the configurable threshold

Fixes #40