### PR TITLE
Fix docs workflow by adding write permissions for GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
@@ -22,3 +24,4 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: ./docs/generated
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR fixes the documentation workflow by adding the required write permissions to the GitHub Actions job for GitHub Pages deployment. 

The previous workflow was failing with a '403 permission denied' error when trying to push to the gh-pages branch.