### PR TITLE
Fix GitHub Pages documentation deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,3 +25,5 @@ jobs:
         with:
           folder: ./docs/generated
           token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          clean-exclude: .nojekyll

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,8 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run docs
+      - name: Create .nojekyll file
+        run: touch ./docs/generated/.nojekyll
       - name: Deploy to GitHub Pages
         if: github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
This PR addresses the 404 error on the GitHub Pages site by:

1. Adding a .nojekyll file to prevent GitHub Pages from using Jekyll processing
2. Explicitly configuring the workflow to use the gh-pages branch for deployment

These changes should resolve the 404 issue at https://uor-foundation.github.io/math-js/ by ensuring the documentation is properly published.