### PR TITLE
Update docs workflow to use GitHub's official Pages deployment action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,9 +19,30 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run docs
-      - name: Deploy to GitHub Pages
-        if: github.ref == 'refs/heads/main'
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
         with:
-          folder: ./docs/generated
-          token: ${{ secrets.GITHUB_TOKEN }}
+          path: ./docs/generated
+
+  # Deploy job
+  deploy:
+    # Add a dependency to the build job
+    needs: docs
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
This PR updates the documentation workflow to use GitHub's official Pages deployment actions instead of a third-party action that deploys to a branch.

Changes:
1. Removed JamesIves/github-pages-deploy-action which was deploying to the gh-pages branch
2. Added actions/upload-pages-artifact and actions/deploy-pages which integrate with GitHub's Pages infrastructure
3. Set up proper permissions and environment for GitHub Pages deployment

This aligns with the repository's GitHub Pages configuration that has been set to deploy from GitHub Actions.