### PR TITLE
Update GitHub Pages actions to latest versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Create .nojekyll file
         run: touch ./docs/generated/.nojekyll
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs/generated
 
@@ -47,4 +47,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR fixes the GitHub Pages deployment workflow by updating the GitHub Pages actions to the latest versions.

The previous workflow was failing with:
> This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3

Changes:
1. Updated actions/upload-pages-artifact from v2 to v3
2. Updated actions/deploy-pages from v2 to v4

These updates should resolve the workflow failure and allow for proper GitHub Pages deployment.