### PR TITLE
Configure package publishing to GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,13 +6,17 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: 'https://npm.pkg.github.com/'
+          scope: '@uor-foundation'
       - run: npm ci
       - run: npm run lint
       - run: npm run typecheck
@@ -20,4 +24,4 @@ jobs:
       - run: npm run build
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -11,13 +11,22 @@ The library introduces **Universal Numbers** – integers encoded by their compl
 ## Installation
 
 ```bash
-npm install uor-math-js
+# Install from GitHub Packages
+npm install @uor-foundation/math-js
 ```
+
+You may need to configure npm to use GitHub Packages by creating a `.npmrc` file in your project:
+
+```
+@uor-foundation:registry=https://npm.pkg.github.com
+```
+
+If you're using a private repository, you'll need to authenticate with GitHub Packages. See [GitHub's documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-to-github-packages) for more details.
 
 ## Basic Usage
 
 ```javascript
-const { UniversalNumber, PrimeMath } = require('uor-math-js');
+const { UniversalNumber, PrimeMath } = require('@uor-foundation/math-js');
 
 // Create universal numbers
 const a = UniversalNumber.fromNumber(42);
@@ -53,7 +62,7 @@ const decimalString = product.toString();
 The library includes a comprehensive configuration system that allows you to adjust memory usage, computation limits, and performance trade-offs:
 
 ```javascript
-const math = require('uor-math-js');
+const math = require('@uor-foundation/math-js');
 
 // Configure the library according to your needs
 math.configure({

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,15 +1,12 @@
 # Release Process
 
-This document outlines the process for creating a new release of the `uor-math-js` package.
+This document outlines the process for creating a new release of the `@uor-foundation/math-js` package.
 
 ## Prerequisites
 
-1. Ensure you have appropriate permissions to publish to the NPM registry.
-2. Make sure you have a GitHub Personal Access Token with appropriate permissions.
-3. Configure your NPM token:
-   ```
-   npm config set //registry.npmjs.org/:_authToken=${NPM_TOKEN}
-   ```
+1. Ensure you have appropriate permissions to publish to GitHub Packages.
+2. Make sure you have a GitHub Personal Access Token with appropriate permissions if you need to publish manually.
+3. No additional configuration is needed for automated publishing through GitHub Actions, as it uses the built-in GITHUB_TOKEN.
 
 ## Release Steps
 
@@ -47,8 +44,8 @@ This document outlines the process for creating a new release of the `uor-math-j
    - Publish the release
 
 5. **Monitor the release**
-   - The GitHub Actions workflow will automatically publish the package to NPM
-   - Verify that the package has been published correctly: https://www.npmjs.com/package/uor-math-js
+   - The GitHub Actions workflow will automatically publish the package to GitHub Packages
+   - Verify that the package has been published correctly by checking the Packages section of the GitHub repository: https://github.com/UOR-Foundation/math-js/packages
 
 ## After Release
 
@@ -60,9 +57,13 @@ This document outlines the process for creating a new release of the `uor-math-j
 If the automatic publishing fails:
 
 1. Check the GitHub Actions logs for errors
-2. Ensure that the NPM_TOKEN secret is properly set in the repository
+2. Ensure that the workflow has proper permissions to write packages
 3. If necessary, you can publish manually:
    ```
+   # Authenticate with GitHub Packages
+   npm login --registry=https://npm.pkg.github.com --scope=@uor-foundation
+   
+   # Then build and publish
    npm ci
    npm run build
    npm publish

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,5 +1,19 @@
 # Math-JS API Documentation
 
+## Installation
+
+To install the package from GitHub Packages:
+
+```bash
+npm install @uor-foundation/math-js
+```
+
+You may need to configure npm to use GitHub Packages by creating a `.npmrc` file in your project:
+
+```
+@uor-foundation:registry=https://npm.pkg.github.com
+```
+
 This document provides the complete API reference for the Math-JS library and the Universal Number framework.
 
 ## Core Classes
@@ -141,7 +155,7 @@ Conversion.toString(factorization, base) // Convert to string in any base
 The library supports dynamic loading of components based on need:
 
 ```javascript
-const { loadComponent } = require('math-js/dynamicLoader');
+const { loadComponent } = require('@uor-foundation/math-js/dynamicLoader');
 const advancedFactorization = await loadComponent('AdvancedFactorization');
 ```
 

--- a/examples/addition-example.js
+++ b/examples/addition-example.js
@@ -1,5 +1,5 @@
 // Example of using the math-js library for addition
-const { UniversalNumber } = require('../src')
+const { UniversalNumber } = require('@uor-foundation/math-js')
 
 // Create two numbers
 const a = new UniversalNumber(123)
@@ -12,7 +12,7 @@ console.log(`${a} + ${b} = ${sum}`)
 // Output: 123 + 789 = 912
 
 // Example using the Utils module for fast exponentiation
-const { internal: { Utils } } = require('../src')
+const { internal: { Utils } } = require('@uor-foundation/math-js')
 
 const base = 2n
 const exponent = 10n

--- a/examples/arithmetic-example.js
+++ b/examples/arithmetic-example.js
@@ -1,5 +1,5 @@
 // Example of using the math-js library for arithmetic operations
-const { UniversalNumber } = require('../src')
+const { UniversalNumber } = require('@uor-foundation/math-js')
 
 // Create numbers
 const a = new UniversalNumber(42)

--- a/examples/conversion-example.js
+++ b/examples/conversion-example.js
@@ -1,5 +1,5 @@
 // Example of using the math-js library for number conversions
-const { UniversalNumber } = require('../src')
+const { UniversalNumber } = require('@uor-foundation/math-js')
 
 // Create a UniversalNumber from various sources
 const fromNumber = UniversalNumber.fromNumber(123)

--- a/examples/custom-base-example.js
+++ b/examples/custom-base-example.js
@@ -4,7 +4,7 @@
  */
 
 // Import the necessary modules
-const { UniversalNumber } = require('../src')
+const { UniversalNumber } = require('@uor-foundation/math-js')
 const { configure, config } = require('../src/config')
 
 // Original base limits (2-36 by default)

--- a/examples/enhanced-architecture-example.js
+++ b/examples/enhanced-architecture-example.js
@@ -3,7 +3,7 @@
  */
 
 // Import the math-js library
-const mathjs = require('../src');
+const mathjs = require('@uor-foundation/math-js');
 const { UniversalNumber, PrimeMath, configure, createStream, createAsync } = mathjs;
 
 console.log('Enhanced Architecture and API Example');

--- a/examples/factorization-example.js
+++ b/examples/factorization-example.js
@@ -1,11 +1,11 @@
 // Example of using the math-js library for prime factorization
-const { UniversalNumber, configure } = require('../src')
+const { UniversalNumber, configure } = require('@uor-foundation/math-js')
 const { 
   factorizeOptimal, 
   factorizeParallel, 
   factorizationCache,
   ellipticCurveMethod
-} = require('../src').internal.Factorization
+} = require('@uor-foundation/math-js').internal.Factorization
 
 console.log('=== Basic Factorization with UniversalNumber ===')
 

--- a/examples/large-number-conversion-example.js
+++ b/examples/large-number-conversion-example.js
@@ -2,7 +2,7 @@
  * Example demonstrating large number conversion options in UniversalNumber
  */
 
-const { UniversalNumber } = require('../src')
+const { UniversalNumber } = require('@uor-foundation/math-js')
 
 console.log('UniversalNumber Large Number Conversion Example')
 console.log('==============================================')

--- a/examples/number-theory-example.js
+++ b/examples/number-theory-example.js
@@ -1,5 +1,5 @@
 // Example of using the math-js library for number theory operations
-const { UniversalNumber } = require('../src')
+const { UniversalNumber } = require('@uor-foundation/math-js')
 
 // Create numbers
 const a = new UniversalNumber(42)

--- a/examples/prime-framework-example.js
+++ b/examples/prime-framework-example.js
@@ -2,7 +2,7 @@
  * Example demonstrating the Prime Framework enhancements to the UniversalNumber class
  */
 
-const { UniversalNumber } = require('../src');
+const { UniversalNumber } = require('@uor-foundation/math-js');
 
 console.log('Prime Framework Enhancements Example');
 console.log('====================================');

--- a/examples/simple-architecture-example.js
+++ b/examples/simple-architecture-example.js
@@ -2,7 +2,7 @@
  * Simple example demonstrating the enhanced library architecture
  */
 
-const mathjs = require('../src');
+const mathjs = require('@uor-foundation/math-js');
 const { UniversalNumber } = mathjs;
 
 console.log('Enhanced Architecture Example (Simplified)');

--- a/examples/usage-example.md
+++ b/examples/usage-example.md
@@ -5,13 +5,19 @@ This document provides examples of how to use the Math-JS library, which impleme
 ## Installation
 
 ```bash
-npm install math-js
+npm install @uor-foundation/math-js
+```
+
+You may need to configure npm to use GitHub Packages by creating a `.npmrc` file in your project:
+
+```
+@uor-foundation:registry=https://npm.pkg.github.com
 ```
 
 ## Basic Usage
 
 ```javascript
-const { UniversalNumber } = require('math-js');
+const { UniversalNumber } = require('@uor-foundation/math-js');
 
 // Create a number
 const num = new UniversalNumber(42);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "uor-math-js",
+  "name": "@uor-foundation/math-js",
   "version": "0.1.0",
   "description": "A JavaScript library implementing the Prime Framework for universal number representation",
   "main": "dist/index.js",
@@ -55,6 +55,7 @@
     "typescript": "^5.4.2"
   },
   "publishConfig": {
+    "registry": "https://npm.pkg.github.com/",
     "access": "public"
   }
 }


### PR DESCRIPTION
This PR reconfigures the package to publish to GitHub Packages instead of npm.

Changes:
1. Updated package name to use the organization scoped format (@uor-foundation/math-js)
2. Modified publishConfig to specify GitHub Packages registry
3. Updated workflow to use GitHub Packages registry URL
4. Changed authentication to use GITHUB_TOKEN instead of NPM_TOKEN
5. Added required GitHub Packages write permissions to the workflow

After merging, the package will be published to GitHub Packages when a new release is created:
- It will be available at https://github.com/UOR-Foundation/math-js/packages
- Users can install it with: npm install @uor-foundation/math-js