### PR TITLE
Bump version to 0.1.1 for initial release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uor-foundation/math-js",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A JavaScript library implementing the Prime Framework for universal number representation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This PR bumps the package version to 0.1.1 to resolve the conflict when publishing to GitHub Packages.

The previous release attempt failed with:
> 409 Conflict - Cannot publish over existing version

This version bump will allow the package to be published while maintaining the same functionality.