### PR TITLE
Update publishing workflow to support npm registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,24 @@ jobs:
           git add dist/
           git diff --quiet && git diff --staged --quiet || git commit -m "build: update dist folder for release [skip ci]"
           git push
-          
+      
+      # Publish to GitHub Packages
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@uor-foundation'
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_REGISTRY}}

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "webpack-cli": "^6.0.1"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
     "access": "public"
   }
 }


### PR DESCRIPTION
## Summary
- Add a new publish-npm job to publish to npm registry using NPM_REGISTRY secret
- Remove registry restriction from package.json to allow publishing to multiple registries
- Keep GitHub packages publishing for backward compatibility

## Test plan
- Release workflow will be tested when a new release is created
- No changes to application code, only CI/CD pipeline

🤖 Generated with [Claude Code](https://claude.ai/code)